### PR TITLE
Adding the ability to override the dropdown icon styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ For more examples visit our [wiki page](https://github.com/azeezat/react-native-
 | placeholderStyle          | `Object`            | `{color: 'blue', fontSize: 15, fontWeight: '500'}`                         |
 | dropdownStyle             | `Object`            | `{borderColor: 'blue', margin: 5, borderWidth:0 ...}`                      |
 | dropdownContainerStyle    | `Object`            | `{backgroundColor: 'red', width: '30%', ...}`                              |
+| dropdownIconStyle         | `Object`            | `{top: 10 , right: 10, ...}`                              |
 | searchInputStyle          | `Object`            | `{backgroundColor: 'red', borderRadius: 0, ...}`                           |
 | selectedItemStyle         | `Object`            | `{fontWeight: '600', color: 'yellow', ...}`                                |
 | multipleSelectedItemStyle | `Object`            | `{backgroundColor: 'red', color: 'yellow', ...}`                           |

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -16,6 +16,7 @@ const Dropdown = ({
   selectedItems,
   labelStyle,
   dropdownStyle,
+  dropdownIconStyle,
   dropdownContainerStyle,
   selectedItemStyle,
   placeholderStyle,
@@ -40,6 +41,7 @@ const Dropdown = ({
         selectedItem={selectedItem}
         selectedItems={selectedItems}
         dropdownStyle={dropdownStyle}
+        dropdownIconStyle={dropdownIconStyle}
         selectedItemStyle={selectedItemStyle}
         multipleSelectedItemStyle={multipleSelectedItemStyle}
         dropdownErrorStyle={dropdownErrorStyle}

--- a/src/components/Dropdown/DropdownSelectedItemsView.tsx
+++ b/src/components/Dropdown/DropdownSelectedItemsView.tsx
@@ -20,6 +20,7 @@ const DropdownSelectedItemsView = ({
   selectedItem,
   selectedItems,
   dropdownStyle,
+  dropdownIconStyle,
   selectedItemStyle,
   placeholderStyle,
   multipleSelectedItemStyle,
@@ -91,7 +92,7 @@ const DropdownSelectedItemsView = ({
           </Text>
         )}
       </ScrollView>
-      <View style={styles.iconStyle}>
+      <View style={[styles.iconStyle, dropdownIconStyle]}>
         <Image source={require('../../asset/arrow-down.png')} />
       </View>
     </Pressable>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ export const DropdownSelect = ({
   labelStyle,
   placeholderStyle,
   dropdownStyle,
+  dropdownIconStyle,
   dropdownContainerStyle,
   dropdownErrorStyle,
   dropdownErrorTextStyle,
@@ -183,6 +184,7 @@ export const DropdownSelect = ({
         handleToggleModal={handleToggleModal}
         labelStyle={labelStyle}
         dropdownStyle={dropdownStyle}
+        dropdownIconStyle={dropdownIconStyle}
         dropdownContainerStyle={dropdownContainerStyle}
         dropdownErrorStyle={dropdownErrorStyle}
         dropdownErrorTextStyle={dropdownErrorTextStyle}

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -14,6 +14,7 @@ export type DropdownProps = {
   isSearchable?: boolean;
   labelStyle?: TextStyle;
   dropdownStyle?: ViewStyle;
+  dropdownIconStyle?: ViewStyle;
   dropdownContainerStyle?: ViewStyle;
   dropdownErrorStyle?: ViewStyle;
   dropdownErrorTextStyle?: TextStyle;


### PR DESCRIPTION
# Description

This adds a new `dropdownIconStyle` prop that allows users to override the positioning styles of the dropdown icon. Currently the dropdown is much taller than a standard form component, and it is possible to make the dropdown much shorter by lowering the `minHeight` on the dropdown, but when doing that, the dropdown arrow is in the wrong place. This gives the ability to reposition the dropdown icon.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

