### PR TITLE
add prop to trigger  hiding of  modal

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ export const DropdownSelect: React.FC<DropdownProps> = ({
   checkboxLabelStyle,
   listHeaderComponent,
   listFooterComponent,
+  hideModal = false,
   ...rest
 }) => {
   const [newOptions, setNewOptions] = useState<any[]>([]);
@@ -180,6 +181,12 @@ export const DropdownSelect: React.FC<DropdownProps> = ({
     setSearchValue('');
     setNewOptions(options);
   };
+
+  useEffect(() => {
+    if (hideModal) {
+      setOpen(false);
+    }
+  }, [hideModal]);
 
   let primary = primaryColor || colors.gray;
   return (

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -40,4 +40,5 @@ export type DropdownProps = {
   placeholderStyle?: TextStyle;
   listHeaderComponent?: React.ReactNode;
   listFooterComponent?: React.ReactNode;
+  hideModal?: boolean;
 };


### PR DESCRIPTION
# Description

Given a button in the modal list header which navigates to a another screen (using React Navigation) when pressed ,  the  dropdown modal's visibility keeps persisted when the new screen is mounted.
Hence, this fix adds a new prop `hideModal` which is `false` by default. the modal get hidden when this value is changed to `true`.
Basically, the `hideModal` prop is set to `true` before calling the `navigate` method from react-navigation. This way, the modal get hidden and the new screen is mounted

## Type of change
- [ ] New feature (non-breaking change which adds functionality)





