### PR TITLE
fix null value propagation on unselect

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,6 +69,7 @@ export const DropdownSelect: React.FC<DropdownProps> = ({
   const handleSingleSelection = (value: any) => {
     if (selectedItem === value) {
       setSelectedItem(null);
+      onValueChange(null); //send value to parent
     } else {
       setSelectedItem(value);
       onValueChange(value); //send value to parent


### PR DESCRIPTION
# Description

Hi I added the propagation of null value during when the single selection is enabled. Currently the parent does not receive any notification that the user deselect a value in dropdown, this would overcame this limitation by sending null to the callback.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

