### PR TITLE
Allow custom ModalProps to be passed to Modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,40 +170,41 @@ For more examples visit our [wiki page](https://github.com/azeezat/react-native-
 
 ## Props
 
-| Proptypes                  | Datatype            | Example                                                              |
-| -------------------------- | ------------------- | -------------------------------------------------------------------- |
-| label                      | `string`            | `Countries`                                                          |
-| placeholder                | `string`            | `Select a country`                                                   |
-| options                    | `Array`             | `[{ name: 'Nigeria', code: 'NG' }, { name: 'Albania', code: 'AL' }]` |
-| optionLabel                | `string`            | `name`                                                               |
-| optionValue                | `string`            | `code`                                                               |
-| error                      | `string`            | `This is a requiredfield`                                            |
-| helperText                 | `string`            | `Only few countries are listed`                                      |
-| selectedValue              | `string` or `Array` | `AL` or `[AL, AX]`                                                   |
-| onValueChange              | `function`          | `()=>{}`                                                             |
-| isMultiple                 | `Boolean`           | `true`                                                               |
-| isSearchable               | `Boolean`           | `true`                                                               |
-| disabled                   | `Boolean`           | `true`                                                               |
-| dropdownIcon               | `React Component`   | `Image` or `<Text> Show <Text>`                                      |
-| labelStyle                 | `Object`            | `{color: 'red', fontSize: 15, fontWeight: '500'}`                    |
-| placeholderStyle           | `Object`            | `{color: 'blue', fontSize: 15, fontWeight: '500'}`                   |
-| dropdownStyle              | `Object`            | `{borderColor: 'blue', margin: 5, borderWidth:0 ...}`                |
-| dropdownContainerStyle     | `Object`            | `{backgroundColor: 'red', width: '30%', ...}`                        |
-| dropdownIconStyle          | `Object`            | `{top: 10 , right: 10, ...}`                                         |
-| searchInputStyle           | `Object`            | `{backgroundColor: 'red', borderRadius: 0, ...}`                     |
-| selectedItemStyle          | `Object`            | `{fontWeight: '600', color: 'yellow', ...}`                          |
-| multipleSelectedItemStyle  | `Object`            | `{backgroundColor: 'red', color: 'yellow', ...}`                     |
-| modalBackgroundStyle       | `Object`            | `{backgroundColor: 'rgba(196, 198, 246, 0.5)'}`                      |
-| modalOptionsContainerStyle | `Object`            | `{padding: 10, backgroundColor: 'cyan',}`                            |
-| dropdownErrorStyle         | `Object`            | `{borderWidth: 2, borderStyle: 'solid'}`                             |
-| dropdownErrorTextStyle     | `Object`            | `{color: 'red', fontWeight:'500'}`                                   |
-| dropdownHelperTextStyle    | `Object`            | `{color: 'green', fontWeight:'500'}`                                 |
-| primaryColor               | `string`            | `blue`                                                               |
-| checkboxSize               | `number`            | `20`                                                                 |
-| checkboxStyle              | `Object`            | `{backgroundColor: 'blue', borderRadius: 30, padding: 10}`           |
-| checkboxLabelStyle         | `Object`            | `{color: 'red', fontWeight:'500'}`                                   |
-| listHeaderComponent        | `React Component`   | `<Text> You can add any component here`                              |
-| listFooterComponent        | `React Component`   | `<Text> You can add any component here`                              |
+| Proptypes                  | Datatype                 | Example                                                              |
+| -------------------------- | ------------------------ | -------------------------------------------------------------------- |
+| label                      | `string`                 | `Countries`                                                          |
+| placeholder                | `string`                 | `Select a country`                                                   |
+| options                    | `Array`                  | `[{ name: 'Nigeria', code: 'NG' }, { name: 'Albania', code: 'AL' }]` |
+| optionLabel                | `string`                 | `name`                                                               |
+| optionValue                | `string`                 | `code`                                                               |
+| error                      | `string`                 | `This is a requiredfield`                                            |
+| helperText                 | `string`                 | `Only few countries are listed`                                      |
+| selectedValue              | `string` or `Array`      | `AL` or `[AL, AX]`                                                   |
+| onValueChange              | `function`               | `()=>{}`                                                             |
+| isMultiple                 | `Boolean`                | `true`                                                               |
+| isSearchable               | `Boolean`                | `true`                                                               |
+| disabled                   | `Boolean`                | `true`                                                               |
+| dropdownIcon               | `React Component`        | `Image` or `<Text> Show <Text>`                                      |
+| labelStyle                 | `Object`                 | `{color: 'red', fontSize: 15, fontWeight: '500'}`                    |
+| placeholderStyle           | `Object`                 | `{color: 'blue', fontSize: 15, fontWeight: '500'}`                   |
+| dropdownStyle              | `Object`                 | `{borderColor: 'blue', margin: 5, borderWidth:0 ...}`                |
+| dropdownContainerStyle     | `Object`                 | `{backgroundColor: 'red', width: '30%', ...}`                        |
+| dropdownIconStyle          | `Object`                 | `{top: 10 , right: 10, ...}`                                         |
+| searchInputStyle           | `Object`                 | `{backgroundColor: 'red', borderRadius: 0, ...}`                     |
+| selectedItemStyle          | `Object`                 | `{fontWeight: '600', color: 'yellow', ...}`                          |
+| multipleSelectedItemStyle  | `Object`                 | `{backgroundColor: 'red', color: 'yellow', ...}`                     |
+| modalBackgroundStyle       | `Object`                 | `{backgroundColor: 'rgba(196, 198, 246, 0.5)'}`                      |
+| modalOptionsContainerStyle | `Object`                 | `{padding: 10, backgroundColor: 'cyan',}`                            |
+| modalProps                 | `ReactNative.ModalProps` | `{supportedOrientations:{['landscape-left', landscape-right']}`      |
+| dropdownErrorStyle         | `Object`                 | `{borderWidth: 2, borderStyle: 'solid'}`                             |
+| dropdownErrorTextStyle     | `Object`                 | `{color: 'red', fontWeight:'500'}`                                   |
+| dropdownHelperTextStyle    | `Object`                 | `{color: 'green', fontWeight:'500'}`                                 |
+| primaryColor               | `string`                 | `blue`                                                               |
+| checkboxSize               | `number`                 | `20`                                                                 |
+| checkboxStyle              | `Object`                 | `{backgroundColor: 'blue', borderRadius: 30, padding: 10}`           |
+| checkboxLabelStyle         | `Object`                 | `{color: 'red', fontWeight:'500'}`                                   |
+| listHeaderComponent        | `React Component`        | `<Text> You can add any component here`                              |
+| listFooterComponent        | `React Component`        | `<Text> You can add any component here`                              |
 
 ## Contributing
 

--- a/src/components/CustomModal/index.tsx
+++ b/src/components/CustomModal/index.tsx
@@ -13,6 +13,7 @@ const CustomModal = ({
   onRequestClose,
   modalBackgroundStyle,
   modalOptionsContainerStyle,
+  modalProps,
   children,
 }: any) => {
   return (
@@ -21,6 +22,7 @@ const CustomModal = ({
       visible={open}
       onRequestClose={() => onRequestClose()}
       animationType="fade"
+      {...modalProps}
     >
       <TouchableOpacity
         onPress={() => handleToggleModal()}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,7 @@ export const DropdownSelect: React.FC<DropdownProps> = ({
   checkboxLabelStyle,
   listHeaderComponent,
   listFooterComponent,
+  modalProps,
   hideModal = false,
   ...rest
 }) => {
@@ -223,6 +224,7 @@ export const DropdownSelect: React.FC<DropdownProps> = ({
         modalBackgroundStyle={modalBackgroundStyle}
         modalOptionsContainerStyle={modalOptionsContainerStyle}
         onRequestClose={() => {}}
+        modalProps={modalProps}
       >
         <DropdownList
           ListHeaderComponent={

--- a/src/types/index.types.ts
+++ b/src/types/index.types.ts
@@ -1,4 +1,9 @@
-import type { ViewStyle, ColorValue, TextStyle } from 'react-native';
+import type {
+  ViewStyle,
+  ColorValue,
+  TextStyle,
+  ModalProps,
+} from 'react-native';
 
 export type DropdownProps = {
   placeholder?: string;
@@ -41,4 +46,5 @@ export type DropdownProps = {
   listHeaderComponent?: React.ReactNode;
   listFooterComponent?: React.ReactNode;
   hideModal?: boolean;
+  modalProps?: ModalProps;
 };


### PR DESCRIPTION
# Description

On iOS apps with fixed horizontal orientation, react native's Modal will cause an exception unless you pass `supportedOrientations={['landscape-left', landscape-right']}`.  This change will allow passing the prop `modalProps={{supportedOrientations:{['landscape-left', landscape-right']}` to the Dropdown component to prevent the crash for users of this library with landscape-only iOS apps.  It would of course allow other modal props to be passed in too.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manual test
Create a fresh RN app that supports horizontal orientations only, as specified in the 'supported interface orientations' Info.plist and under 'Deployment Info' in xCode.  Now add the component that consumes the Dropdown component exported by react-native-input-select (main branch).
In a release build, the component will be unresponsive and the app may crash soon after tapping it.  In dev mode, the component will work but with the error message "Modal was presented with 0x2 orientations mask but the application only supports 0x18.  Add more interface orientations to your app's Info.plist to fix this. Note this will crash in non-dev mode".  
Now switch to this feature branch and add `modalProps={{supportedOrientations:{['landscape-left', landscape-right']}` prop to the Dropdown and re-build.  The component should now work as expected.

**Test Configuration**:
* Firmware version: 
* Hardware:
* Toolchain: 
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
