### PR TITLE
Fixed Dropdown disabled bahviour

### DIFF
--- a/src/components/Dropdown/DropdownSelectedItemsView.tsx
+++ b/src/components/Dropdown/DropdownSelectedItemsView.tsx
@@ -71,6 +71,7 @@ const DropdownSelectedItemsView = ({
                   multipleSelectedItemStyle,
                 ]}
                 label={label}
+                disabled={disabled}
               />
             ))
           ) : (
@@ -81,6 +82,7 @@ const DropdownSelectedItemsView = ({
               }}
               style={[styles.blackText, selectedItemStyle]}
               label={getSelectedItemsLabel()}
+              disabled={disabled}
             />
           )}
           {!selectedItem && selectedItems?.length === 0 && (
@@ -88,6 +90,7 @@ const DropdownSelectedItemsView = ({
               onPress={() => handleToggleModal()}
               style={[styles.blackText, placeholderStyle]}
               label={placeholder ?? 'Select an option'}
+              disabled={disabled}
             />
           )}
         </View>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -276,6 +276,9 @@ export const DropdownSelect: React.FC<DropdownProps> = ({
    * Modal
    *==========================================*/
   const handleToggleModal = () => {
+    if (disabled){ // protecting any toggleModal invocation when Dropdown is disabled by not activating state
+      return; 
+    }
     setOpen(!open);
     setSearchValue('');
     setNewOptions(options);


### PR DESCRIPTION
# Description

When the dropdown is disabled the user can still click on the selected value and open the dialog to change the value.

Fixes # (issue)

## Type of change

I have propagated disabled prop to DropdownContent component to communicate to TouchableOpacity that this input is disabled. I also protected the handleToggleModal to prevent any invocation via ref by not setting state when component is disabled.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Disabled input does not open selection modal
- [X] Non disabled input open selection modal


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas

