### PR TITLE
fix: enforce label to a string, so we avoid the issue of a label being numerical 0

### DIFF
--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -34,7 +34,7 @@ const CheckBox = ({
         checkboxStyle?.borderColor ||
         styles.checkbox.borderColor,
   };
-
+  label = String(label);
   return (
     <Pressable
       onPress={onChange ? () => onChange(!value) : null}


### PR DESCRIPTION
# Description
Version "1.3.18".
TL;DR: `<Dropdown>` (and especially Checkbox) crashes if using a numerical 0, in one of the options' labels.

To use the `options` props, we must pass an object with 2 keys, acting as `label` and `value`. In case one uses a numerical zero, we happen to witness a crash.

Fixes #90 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```typescript
<Dropdown
    options={[{ label: 0, value: "numerical_0" }, { label: 1, value: "numerical_one" }]}
    optionLabel="label"
    optionValue="value"
    selectedValue={0}
    onValueChange={onValueChange}
/>
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (I could not get to do a npm i && npm test)
- [ ] New and existing unit tests pass locally with my changes (I could not get to do a npm i && npm test)
- [x] Any dependent changes have been merged and published in downstream modules

