### PR TITLE
reset options list to initial state when search input is cleared

### DIFF
--- a/src/hooks/use-search.ts
+++ b/src/hooks/use-search.ts
@@ -25,8 +25,12 @@ export const useSearch = ({
     TFlatList | TSectionList
   >(initialOptions);
 
+  const resetOptionsToDefault = (options: TFlatList | TSectionList) => {
+    setFilteredOptions(options);
+  };
+
   useEffect(() => {
-    setFilteredOptions(initialOptions);
+    resetOptionsToDefault(initialOptions);
     return () => {};
   }, [initialOptions]);
 
@@ -82,6 +86,9 @@ export const useSearch = ({
   useEffect(() => {
     if (searchValue) {
       onSearch(searchValue);
+    }
+    else{
+      resetOptionsToDefault(initialOptions)
     }
   }, [onSearch, searchValue]);
 


### PR DESCRIPTION
# Description

This address the the challenge of search options remaining the same even after clearing the search box. Ideally, the options should be reset to the default list after the search box is cleared.

Fixes # (issue)
See Related Issue: https://github.com/azeezat/react-native-select/issues/96

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
This is has been manually tested on android 14


**Test Configuration**:
* Firmware version:
* Hardware: Samsung Device
* Toolchain:
* SDK: android 14

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

