### PR TITLE
fix: Selectively show custom checkbox component

### DIFF
--- a/src/components/CheckBox/index.tsx
+++ b/src/components/CheckBox/index.tsx
@@ -49,7 +49,7 @@ const CheckBox = ({
         style={[styles.checkbox, checkboxStyle, fillColor]}
         aria-checked={value}
       >
-        {checkboxComponent || (
+        {(value && checkboxComponent) || (
           <View style={checkBoxDimensions}>
             {value ? (
               <Image


### PR DESCRIPTION
# Description

This PR changes the behaviour of the underlying checkbox component to not render unless the item is **selected**. 

Fixes #123

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

People previously having relied on their custom checkbox always rendering will be impacted. As the checkbox is unable to know if it's selected or not I wouldn't expect anyone to be negatively impacted by this.

# How Has This Been Tested?
## Before

![before image](https://github.com/user-attachments/assets/1d205f4e-d562-4af1-b433-8852abffea38)

## After
![after image](https://github.com/user-attachments/assets/ab003053-4b79-4c8e-952a-f283adb5abf8)


**Test Configuration**:
* Firmware version: Android 15
* Hardware: OnePlus 11 5G
* Toolchain: /
* SDK: 35

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

