### PR TITLE
fix: Android KeyboardAvoidingView issue in edgeToEdgeEnabled in new architecture

### DIFF
--- a/src/components/CustomModal/index.tsx
+++ b/src/components/CustomModal/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-native/no-inline-styles */
-import React, { PropsWithChildren, ReactElement } from 'react';
+import React from 'react';
 import {
   KeyboardAvoidingView,
   Modal,
@@ -13,18 +13,6 @@ import {
 import { colors } from '../../styles/colors';
 import { TCustomModalControls } from 'src/types/index.types';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-
-// In iOS, `SafeAreaView` does not automatically account on keyboard.
-// Therefore, for iOS we need to wrap the content in `KeyboardAvoidingView`.
-const ModalContentWrapper = ({ children }: PropsWithChildren): ReactElement => {
-  return Platform.OS === 'ios' ? (
-    <KeyboardAvoidingView style={[{ flex: 1 }]} behavior="padding">
-      {children}
-    </KeyboardAvoidingView>
-  ) : (
-    <>{children}</>
-  );
-};
 
 const CustomModal = ({
   visible,
@@ -44,15 +32,13 @@ const CustomModal = ({
       animationType="fade"
       {...modalControls?.modalProps}
     >
-      {/*Used to fix the select with search box behavior in iOS*/}
-      <ModalContentWrapper>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
         <TouchableOpacity
           onPress={onRequestClose}
-          style={[
-            styles.modalContainer,
-            styles.modalBackgroundStyle,
-            modalControls?.modalBackgroundStyle,
-          ]}
+          style={[styles.modalContainer, modalControls?.modalBackgroundStyle]}
           aria-label="close modal"
         >
           {/* Added this `TouchableWithoutFeedback` wrapper because of the closing modal on expo web */}
@@ -69,7 +55,7 @@ const CustomModal = ({
             </View>
           </TouchableWithoutFeedback>
         </TouchableOpacity>
-      </ModalContentWrapper>
+      </KeyboardAvoidingView>
     </Modal>
   );
 };
@@ -78,8 +64,8 @@ const styles = StyleSheet.create({
   modalContainer: {
     flex: 1,
     justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
-  modalBackgroundStyle: { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
   modalOptionsContainer: {
     maxHeight: '50%',
     backgroundColor: colors.white,


### PR DESCRIPTION
# Description

The library needs to support the changes to the KeyboardAvoidingView in the new architecture when edgeToEdge mode is enabled.

Fixes #125 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ x] Test A

1. In `gradle.properties`, set `edgeToEdgeEnabled=true`
2. Open a searchable dropdown and type a word in the search box
3. The keyboard should not draw over the items but it should appear below the items container

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

